### PR TITLE
Color proc sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,5 @@ I am now developing in Sublime Text 3 beta, though I believe everything works in
   1. Fix error/warning check.
   2. (Possible?) Bring ST3 to the fore upon completion of a job.
 2. Make installable via [Package Control](http://wbond.net/sublime_packages/package_control).  (Subject to Package Control's compatibility w/ST3.)
-3. Polish syntax definition.  In particular:
-  1. Color PROC SQL & any trailing options as other procs are colored.
+3. Polish syntax definition.
 4. Add a menu item to allow quick access to SAS.sublime-settings

--- a/sytaxes/sas.YAML-tmLanguage
+++ b/sytaxes/sas.YAML-tmLanguage
@@ -50,8 +50,13 @@ patterns:
 - comment: Looks like for this to work there must be a *name* as well as the patterns/include
     bit.
   name: meta.sql.sas
-  begin: (?i:\bproc\s*sql\b.*)
-  end: (?i:\bquit\s*;)
+  begin: (?i:\b(proc\s*(sql))\b)
+  beginCaptures:
+    '1': {name: support.function.sas}
+    '2': {name: support.class.sas}
+  end: (?i:\b(quit)\s*;)
+  endCaptures:
+    '1': {name: keyword.control.sas}
   patterns:
   - include: '#starComment'
   - include: '#blockComment'

--- a/sytaxes/sas.tmLanguage
+++ b/sytaxes/sas.tmLanguage
@@ -148,11 +148,32 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?i:\bproc\s*sql\b.*)</string>
+			<string>(?i:\b(proc\s*(sql))\b)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.sas</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>support.class.sas</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Looks like for this to work there must be a *name* as well as the patterns/include bit.</string>
 			<key>end</key>
-			<string>(?i:\bquit\s*;)</string>
+			<string>(?i:\b(quit)\s*;)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.sas</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>meta.sql.sas</string>
 			<key>patterns</key>


### PR DESCRIPTION
Modified the syntax file to color 'proc sql', its options, and 'quit' keyword.
This PR deals issue #14.

current:
![sas_package_color_proc_sql_previous](https://cloud.githubusercontent.com/assets/729653/13720012/1e2fb036-e842-11e5-99b3-04166607643b.png)

this commit:
![sas_package_color_proc_sql](https://cloud.githubusercontent.com/assets/729653/13719993/cf1f9fb0-e841-11e5-8dfb-c3d86afe4d7c.png)
